### PR TITLE
Changed examples/iot to examples/iot-gateway

### DIFF
--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -319,7 +319,7 @@ Go under the ``examples/iot`` directory:
 
 .. code-block:: shell
     
-    cd examples/iot
+    cd examples/iot-gateway
 
 Start an ``ipython`` session:
 


### PR DESCRIPTION
When in the docker image for auditee, the examples folder contains the iot-gateway folder and not iot, as written in the tutorial.